### PR TITLE
Do not omit `0` values

### DIFF
--- a/lib/metrics/CarbonMetricReporter.ts
+++ b/lib/metrics/CarbonMetricReporter.ts
@@ -394,7 +394,7 @@ export class CarbonMetricReporter extends ScheduledMetricReporter<CarbonMetricRe
      */
     protected reportMeter(meter: Meter, ctx: MetricSetReportContext<Meter>): CarbonData {
         const value = meter.getCount();
-        if (!value || isNaN(value)) {
+        if (value === undefined || value === null || isNaN(value)) {
             return null;
         }
         const tags = this.buildTags(ctx.registry, meter);


### PR DESCRIPTION
Events with value `0` are not reported